### PR TITLE
Refactor REGISTER_PLAYER message calls

### DIFF
--- a/src/TiciTacaToeyGameEngine.ts
+++ b/src/TiciTacaToeyGameEngine.ts
@@ -12,6 +12,8 @@ import {
   CalculateWinnerInputType,
   CalculateWinnerOutputType,
 } from "./model";
+import WebSocket = require("ws");
+
 const uniq = require("lodash.uniq");
 
 const EMPTY_POSITION = "-";
@@ -152,11 +154,7 @@ class TiciTacaToeyGameEngine implements GameEngine {
   transition(message: Message) {
     switch (message.type) {
       case MessageTypes.REGISTER_PLAYER: {
-        const { type, ...playerData } = message;
-        this.players = {
-          ...this.players,
-          [message.playerId]: { ...playerData },
-        };
+        this.players = addPlayer(this.players, message.playerId, message.name, message.connection);
         break;
       }
       case MessageTypes.PLAYER_DISCONNECT: {
@@ -185,6 +183,9 @@ class TiciTacaToeyGameEngine implements GameEngine {
         break;
       }
       case MessageTypes.START_GAME: {
+        if (!(message.playerId in this.players)){
+          this.players = addPlayer(this.players, message.playerId, "", message.connection);
+        }
         const game = {
           gameId: message.gameId,
           name: message.name,
@@ -207,6 +208,10 @@ class TiciTacaToeyGameEngine implements GameEngine {
         break;
       }
       case MessageTypes.JOIN_GAME: {
+        if (!this.players[message.playerId]){
+          this.players = addPlayer(this.players, message.playerId, "", message.connection);
+        }
+
         const gameId = message.gameId;
 
         const updatedPlayersList = uniq([
@@ -406,6 +411,21 @@ class TiciTacaToeyGameEngine implements GameEngine {
       JSON.stringify({ ...error, message, type: "ERROR" })
     );
   }
+}
+
+const addPlayer = (
+  players: {
+    [key: string]: ConnectedPlayer;
+  },
+  playerId: string,
+  name: string,
+  connection: WebSocket
+  ): any => {
+  players = {
+    ...players,
+    [playerId]: { "playerId": playerId, "name": name, "connection": connection },
+  };
+  return players;
 }
 
 const calculateNextTurn = (

--- a/src/TiciTacaToeyGameEngine.ts
+++ b/src/TiciTacaToeyGameEngine.ts
@@ -208,7 +208,7 @@ class TiciTacaToeyGameEngine implements GameEngine {
         break;
       }
       case MessageTypes.JOIN_GAME: {
-        if (!this.players[message.playerId]){
+        if (!(message.playerId in this.players)){
           this.players = addPlayer(this.players, message.playerId, "", message.connection);
         }
 
@@ -421,11 +421,10 @@ const addPlayer = (
   name: string,
   connection: WebSocket
   ): any => {
-  players = {
+  return {
     ...players,
     [playerId]: { "playerId": playerId, "name": name, "connection": connection },
   };
-  return players;
 }
 
 const calculateNextTurn = (

--- a/src/server.ts
+++ b/src/server.ts
@@ -57,14 +57,6 @@ log(engine);
 
 wss.on("connection", (ws) => {
   const playerId = uuid();
-  engine
-    .play({
-      type: MessageTypes.REGISTER_PLAYER,
-      playerId,
-      name: "",
-      connection: ws,
-    })
-    .then(log);
   ws.on("message", (data: string) => {
     let message: Message = null;
     try {


### PR DESCRIPTION
- instead of registering player on connection, player is registered in START_GAME or JOIN_GAME if not yet registered
- REGISTER_PLAYER still used the same to update name
